### PR TITLE
- doc(rust-docs): Added rust-doc for module & function documentation with metadata and descriptions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,18 @@
+//! ## RushX - Main Entry Point
+//!
+//! Binary entry point for RushX.
+//!
+//! ## Metadata
+//!
+//! - **File**: src/main.rs
+//! - **Module**: main
+//! - **Last Update**: 02/17/2026
+//! - **Last Updated By**: sch0penheimer
+//! - **Version**: 0.1.0
+//! - **Copyright**: © 2026 The HaiKaw Pr0tocol
+
+/*=============================================================================*/
+
 mod rushx_app;
 mod rushx_core;
 mod rushx_exec;

--- a/src/rushx_app/mod.rs
+++ b/src/rushx_app/mod.rs
@@ -1,8 +1,30 @@
-use std::io::{self, Write};
+//! ## `rushx_app` <ins>module</ins>: RushX Application Dispatcher
+//!
+//! Application entry point and CLI dispatcher. Contains the main REPL
+//! loop, dispatching to builtins and external commands via
+//! the execution engine.
+//!
+//! ### Metadata
+//!
+//! - **File**: src/rushx_app/mod.rs
+//! - **Module**: rushx_app
+//! - **Last Update**: 02/17/2026
+//! - **Last Updated By**: sch0penheimer
+//! - **Version**: 0.1.0
+//! - **Copyright**: © 2026 The HaiKaw Pr0tocol
+
+/*=============================================================================*/
 
 use crate::rushx_exec;
 use crate::rushx_term;
+use std::io::{self, Write};
 
+/// Dispatches to shell REPL or terminal GUI based on CLI arguments.
+///
+/// ### Behavior
+/// - If `--rushx-shell` flag is present → launches interactive shell REPL
+/// - Otherwise → launches GTK terminal emulator window
+/// 
 pub fn run() {
     let args: Vec<String> = std::env::args().collect();
 
@@ -13,9 +35,18 @@ pub fn run() {
     }
 }
 
+/// Main Interactive shell REPL loop.
+///
+/// ### Behavior
+/// - Prints prompt (`$ `)
+/// - Reads line from stdin
+/// - Parses whitespace-delimited arguments
+/// - Dispatches builtins (`exit`, `echo`, `type`) or external commands
+///
+/// # Exit
+/// Terminates on `exit` builtin or EOF.
+/// 
 fn run_shell() {
-    println!("Hi from RushX !!");
-
     loop {
         print!("$ ");
         io::stdout().flush().unwrap();

--- a/src/rushx_core/ast.rs
+++ b/src/rushx_core/ast.rs
@@ -1,1 +1,16 @@
-// AST types will live here.
+// # AST - Abstract Syntax Tree
+//
+// Abstract Syntax Tree node definitions for parsed shell commands.
+// Represents command structures, pipelines, redirections, control flow,
+// and compound statements in a type-safe, hierarchical format.
+//
+// ## Metadata
+//
+// - **File**: src/rushx_core/ast.rs
+// - **Module**: rushx_core::ast
+// - **Last Update**: 02/17/2026
+// - **Last Updated By**: sch0penheimer
+// - **Version**: 0.1.0
+// - **Copyright**: © 2026 The HaiKaw Pr0tocol
+
+/*=============================================================================*/

--- a/src/rushx_core/error.rs
+++ b/src/rushx_core/error.rs
@@ -1,1 +1,16 @@
-// Shared error types will live here.
+// # Error Types
+//
+// Unified error types for shell operations. Covers parsing errors,
+// expansion failures, execution errors, and system call failures.
+// Provides structured error reporting with context and diagnostics.
+//
+// ## Metadata
+//
+// - **File**: src/rushx_core/error.rs
+// - **Module**: rushx_core::error
+// - **Last Update**: 02/17/2026
+// - **Last Updated By**: sch0penheimer
+// - **Version**: 0.1.0
+// - **Copyright**: © 2026 The HaiKaw Pr0tocol
+
+/*=============================================================================*/

--- a/src/rushx_core/mod.rs
+++ b/src/rushx_core/mod.rs
@@ -1,3 +1,20 @@
+//! ## `rushx_core` <ins>module</ins>: Core Types & Shared Data Structures
+//!
+//! Shared types and core data structures. Contains AST definitions for parsed
+//! commands, error types for the execution engine, and shell state management
+//! types. Provides foundational types used across parser, expander, and executor.
+//!
+//! ## Metadata
+//!
+//! - **File**: src/rushx_core/mod.rs
+//! - **Module**: rushx_core
+//! - **Last Update**: 02/17/2026
+//! - **Last Updated By**: sch0penheimer
+//! - **Version**: 0.1.0
+//! - **Copyright**: © 2026 The HaiKaw Pr0tocol
+
+/*=============================================================================*/
+
 pub mod ast;
 pub mod error;
 pub mod state;

--- a/src/rushx_core/state.rs
+++ b/src/rushx_core/state.rs
@@ -1,1 +1,16 @@
-// Shared shell state will live here.
+// # Shell State Management
+//
+// Shell runtime state management. Tracks environment variables,
+// job table, foreground process group, shell options, and command
+// history. Provides thread-safe state mutation APIs.
+//
+// ## Metadata
+//
+// - **File**: src/rushx_core/state.rs
+// - **Module**: rushx_core::state
+// - **Last Update**: 02/17/2026
+// - **Last Updated By**: sch0penheimer
+// - **Version**: 0.1.0
+// - **Copyright**: © 2026 The HaiKaw Pr0tocol
+
+/*=============================================================================*/

--- a/src/rushx_exec/mod.rs
+++ b/src/rushx_exec/mod.rs
@@ -1,3 +1,25 @@
+//! ## `rushx_exec` <ins>module</ins>: Execution Engine
+//!
+//! Command execution engine. Handles fork/exec for external commands, builtin
+//! detection and dispatch, PATH resolution with permission checking. Manages
+//! process lifecycle from spawn to waitpid, with proper exit status reporting.
+//!
+//! Syscall functions like `execvp(const char *file, char * const argv[])` require C strings.
+//! Direct Rust strings would cause undefined behavior (reading past memory). We convert
+//! at FFI boundaries using `CString::new()` to ensure null termination (**CString**: Rust's owned, null-terminated C string wrapper)
+//!
+//!
+//! ## Metadata
+//!
+//! - **File**: src/rushx_exec/mod.rs
+//! - **Module**: rushx_exec
+//! - **Last Update**: 02/17/2026
+//! - **Last Updated By**: sch0penheimer
+//! - **Version**: 0.1.0
+//! - **Copyright**: © 2026 The HaiKaw Pr0tocol
+
+/*=============================================================================*/
+
 use std::env;
 use std::ffi::CString;
 use std::fs;
@@ -6,13 +28,32 @@ use std::os::unix::fs::PermissionsExt;
 use nix::sys::wait::{WaitStatus, waitpid};
 use nix::unistd::{ForkResult, execvp, fork};
 
+/// Executes an external command via fork/exec.
+///
+/// ### Arguments
+/// - `cmd`: Command name (resolved via PATH)
+/// - `args`: Argument vector (includes `cmd` at argv[0] - POSIX requirement)
+///
+/// ### Behavior
+/// - Searches PATH for executable
+/// - Forks child process
+/// - Child: overlays with `execvp`
+/// - Parent: waits for child termination via `waitpid`
+///
+/// ### Output
+/// - Prints error to stderr on non-zero exit or command not found
+///
+/// ### Some FFI Notes
+/// The `execvp` C syscall function expects null-terminated strings. We convert Rust strings
+/// to `CString` (owned, null-terminated) to satisfy this.
+///
 pub fn run_external(cmd: &str, args: &[&str]) {
     match find_executable_in_path(cmd) {
         Some(path) => {
             let path_cstr = CString::new(path.to_str().unwrap()).unwrap();
             let mut c_args: Vec<CString> = Vec::with_capacity(args.len());
 
-            // argv[0] must be the command name (POSIX requirement).
+            //** argv[0] must be the command name (POSIX requirement) **//
             c_args.push(CString::new(cmd).unwrap());
 
             for &arg in &args[1..] {
@@ -42,10 +83,27 @@ pub fn run_external(cmd: &str, args: &[&str]) {
     }
 }
 
+/// Checks if a command is a shell builtin.
+///
+/// ### Arguments
+/// - `cmd`: Command name
+///
+/// ### Returns
+/// `true` if `cmd` is `exit`, `echo`, or `type`
+/// 
 pub fn is_builtin(cmd: &str) -> bool {
     matches!(cmd, "exit" | "echo" | "type")
 }
 
+/// Implements the `type` builtin command.
+///
+/// ### Arguments
+/// - `cmd`: Command name to inspect
+///
+/// ### Output
+/// - Prints whether `cmd` is a builtin or external (with full path)
+/// - Prints "not found" if neither
+/// 
 pub fn type_command(cmd: &str) {
     if is_builtin(cmd) {
         println!("{} is a shell builtin", cmd);
@@ -58,6 +116,20 @@ pub fn type_command(cmd: &str) {
     }
 }
 
+/// Searches PATH for an executable command.
+///
+/// ### Arguments
+/// - `cmd`: Command name (no path separators)
+///
+/// ### Returns
+/// - `Some(PathBuf)` if found and executable (mode & 0111 != 0)
+/// - `None` otherwise
+///
+/// ### Algorithm
+/// - Iterates PATH directories
+/// - Joins `cmd` to each path
+/// - Checks: file exists + is regular file + has execute permission
+///
 pub fn find_executable_in_path(cmd: &str) -> Option<std::path::PathBuf> {
     if let Ok(paths) = env::var("PATH") {
         for path in env::split_paths(&paths) {

--- a/src/rushx_expand/glob.rs
+++ b/src/rushx_expand/glob.rs
@@ -1,1 +1,16 @@
-// Globbing logic will live here.
+// # Filename Globbing & Pattern Matching
+//
+// Filename globbing and pattern matching. Expands wildcards (*, ?, [...]),
+// brace expansions, and character classes. Matches patterns against
+// filesystem entries with proper locale and collation rules.
+//
+// ## Metadata
+//
+// - **File**: src/rushx_expand/glob.rs
+// - **Module**: rushx_expand::glob
+// - **Last Update**: 02/17/2026
+// - **Last Updated By**: sch0penheimer
+// - **Version**: 0.1.0
+// - **Copyright**: © 2026 The HaiKaw Pr0tocol
+
+/*=============================================================================*/

--- a/src/rushx_expand/mod.rs
+++ b/src/rushx_expand/mod.rs
@@ -1,3 +1,20 @@
+//! ## `rushx_expand` <ins>module</ins>: Command Expansion & Resolution
+//!
+//! Command expansion and resolution. Performs variable substitution, globbing,
+//! tilde expansion, and PATH resolution. Transforms parsed AST nodes into
+//! fully-resolved command vectors ready for execution.
+//!
+//! ## Metadata
+//!
+//! - **File**: src/rushx_expand/mod.rs
+//! - **Module**: rushx_expand
+//! - **Last Update**: 02/17/2026
+//! - **Last Updated By**: sch0penheimer
+//! - **Version**: 0.1.0
+//! - **Copyright**: © 2026 The HaiKaw Pr0tocol
+
+/*=============================================================================*/
+
 pub mod glob;
 pub mod path;
 pub mod vars;

--- a/src/rushx_expand/path.rs
+++ b/src/rushx_expand/path.rs
@@ -1,1 +1,16 @@
-// PATH resolution and search helpers will live here.
+// # PATH Resolution & Command Lookup
+//
+// PATH environment variable resolution and command lookup. Searches
+// directories in PATH for executable files, validates permissions,
+// and resolves relative paths to absolute canonical forms.
+//
+// ## Metadata
+//
+// - **File**: src/rushx_expand/path.rs
+// - **Module**: rushx_expand::path
+// - **Last Update**: 02/17/2026
+// - **Last Updated By**: sch0penheimer
+// - **Version**: 0.1.0
+// - **Copyright**: © 2026 The HaiKaw Pr0tocol
+
+/*=============================================================================*/

--- a/src/rushx_expand/vars.rs
+++ b/src/rushx_expand/vars.rs
@@ -1,1 +1,16 @@
-// Variable expansion logic will live here.
+// # Variable Expansion & Parameter Substitution
+//
+// Variable expansion and parameter substitution. Handles $VAR, ${VAR},
+// special parameters ($?, $$, $#), and expansion modifiers (:-, :=, :+).
+// Performs word splitting and quote removal post-expansion.
+//
+// ## Metadata
+//
+// - **File**: src/rushx_expand/vars.rs
+// - **Module**: rushx_expand::vars
+// - **Last Update**: 02/17/2026
+// - **Last Updated By**: sch0penheimer
+// - **Version**: 0.1.0
+// - **Copyright**: © 2026 The HaiKaw Pr0tocol
+
+/*=============================================================================*/

--- a/src/rushx_parser/lexer.rs
+++ b/src/rushx_parser/lexer.rs
@@ -1,1 +1,16 @@
-// Tokenization logic will live here.
+// # Lexical Analysis & Tokenization
+//
+// Lexical analysis and tokenization. Converts raw input strings into
+// a token stream, handling quotes, escapes, operators, whitespace,
+// and special characters according to POSIX shell syntax rules.
+//
+// ## Metadata
+//
+// - **File**: src/rushx_parser/lexer.rs
+// - **Module**: rushx_parser::lexer
+// - **Last Update**: 02/17/2026
+// - **Last Updated By**: sch0penheimer
+// - **Version**: 0.1.0
+// - **Copyright**: © 2026 The HaiKaw Pr0tocol
+
+/*=============================================================================*/

--- a/src/rushx_parser/mod.rs
+++ b/src/rushx_parser/mod.rs
@@ -1,2 +1,19 @@
+//! ## `rushx_parser` <ins>module</ins>: Command Parser & Tokenizer
+//!
+//! Command parsing and tokenization. Transforms raw input strings into
+//! structured AST nodes. Handles POSIX syntax elements: quotes, escapes,
+//! operators, pipelines, redirections, and control structures.
+//!
+//! ## Metadata
+//!
+//! - **File**: src/rushx_parser/mod.rs
+//! - **Module**: rushx_parser
+//! - **Last Update**: 02/17/2026
+//! - **Last Updated By**: sch0penheimer
+//! - **Version**: 0.1.0
+//! - **Copyright**: © 2026 The HaiKaw Pr0tocol
+
+/*=============================================================================*/
+
 pub mod lexer;
 pub mod parse;

--- a/src/rushx_parser/parse.rs
+++ b/src/rushx_parser/parse.rs
@@ -1,1 +1,16 @@
-// Parser logic will live here.
+// # Recursive Descent Parser
+//
+// Recursive descent parser for shell command syntax. Consumes token
+// stream from lexer and constructs AST nodes. Handles operator
+// precedence, associativity, and nested command structures.
+//
+// ## Metadata
+//
+// - **File**: src/rushx_parser/parse.rs
+// - **Module**: rushx_parser::parse
+// - **Last Update**: 02/17/2026
+// - **Last Updated By**: sch0penheimer
+// - **Version**: 0.1.0
+// - **Copyright**: © 2026 The HaiKaw Pr0tocol
+
+/*=============================================================================*/

--- a/src/rushx_term/mod.rs
+++ b/src/rushx_term/mod.rs
@@ -1,9 +1,36 @@
+//! ## `rushx_term` <ins>module</ins>: Terminal Emulator (GTK4)
+//!
+//! GTK4-based terminal emulator GUI. Manages application window lifecycle,
+//! rendering pipeline, and drawing surface. Currently paints a solid background;
+//! future iterations will integrate PTY I/O, ANSI parsing, and text rendering.
+//!
+//! ## Metadata
+//!
+//! - **File**: src/rushx_term/mod.rs
+//! - **Module**: rushx_term
+//! - **Last Update**: 02/17/2026
+//! - **Last Updated By**: sch0penheimer
+//! - **Version**: 0.1.0
+//! - **Copyright**: © 2026 The HaiKaw Pr0tocol
+
+/*=============================================================================*/
+
 use gtk::prelude::*;
 use gtk::{Application, ApplicationWindow, DrawingArea};
 use gtk4 as gtk;
 
 const BG_COLOR: (f64, f64, f64) = (0.117, 0.117, 0.180);
 
+/// Constructs the GTK terminal window UI.
+///
+/// ### Arguments
+/// - `app`: GTK Application handle
+///
+/// ### Behavior
+/// - Creates a 800x500 window
+/// - Attaches a DrawingArea with solid background color
+/// - Presents the window on screen
+/// 
 fn build_ui(app: &Application) {
     let window = ApplicationWindow::builder()
         .application(app)
@@ -23,6 +50,12 @@ fn build_ui(app: &Application) {
     window.present();
 }
 
+/// Launches the RushX terminal emulator window.
+///
+/// ### Behavior
+/// - Initializes GTK application with ID `org.rushx.terminal`
+/// - Wires `build_ui` to activation signal
+/// - Enters GTK main event loop (blocks until window closes)
 pub fn run() {
     let app = Application::builder()
         .application_id("org.rushx.terminal")


### PR DESCRIPTION
Applied markdown-friendly rustdoc format across all files:

**Module headers** (`mod.rs` / file headers):
```rust
//! ## `module_name` <ins>module</ins>: Purpose
//!
//! Description of module responsibility.
//!
//! ## Metadata
//! - **File**: path/to/file.rs
//! - **Module**: module_name
//! - **Last Update**: 02/17/2026
//! - **Last Updated By**: sch0penheimer
//! - **Version**: 0.1.0
//! - **Copyright**: © 2026 The HaiKaw Pr0tocol

/*=============================================================================*/
```

**Function documentation**:
```rust
/// Concise one-liner description.
///
/// ### Arguments
/// - `param`: Description
///
/// ### Returns
/// Description of return value
///
/// ### Behavior / Algorithm
/// Implementation details
///
/// ### Output / Side Effects
/// What happens when called
