### PR TITLE
- feat(rushx_term): Implemented clear (CSI 2J/3J) and exit-kills-app + decoupled module build_ui()

### DIFF
--- a/src/rushx_term/mod.rs
+++ b/src/rushx_term/mod.rs
@@ -80,23 +80,65 @@ pub fn run_rushx_terminal() -> () {
 /// - `master_fd`: Raw PTY master file descriptor for bidirectional shell I/O
 ///
 /// ### Behavior
-/// 1. Allocates shared state for the terminal text buffer and cursor visibility
-/// 2. Spawns a thread to read from `master_fd` and send output to the main thread via an mpsc channel
-/// 3. Sets up a `DrawingArea` with a custom draw function to render the terminal text and cursor
-/// 4. Sets up a keyboard event controller to capture key presses and write them to `master_fd` as input to the shell
-/// 5. Starts timers for redrawing on new output and blinking the cursor
-/// 6. Presents the window and enters the GTK main loop
+/// Orchestrates the five subsystems that make up the terminal:
+/// 1. `spawn_reader_thread()`, background thread reading PTY master → mpsc channel
+/// 2. `setup_draw_func()`, Cairo rendering of text buffer and cursor
+/// 3. `setup_poll_timer()`, 16ms timer draining channel → buffer → redraw
+/// 4. `setup_blink_timer()`, 500ms cursor blink toggle
+/// 5. `setup_keyboard()`, keyboard event controller writing to PTY master
 ///
 fn build_ui(app: &Application, master_fd: RawFd) -> () {
     let text_buffer: Rc<RefCell<String>> = Rc::new(RefCell::new(String::new()));
     let cursor_visible: Rc<RefCell<bool>> = Rc::new(RefCell::new(true));
 
-    //-- PTY reader thread → mpsc channel → GTK main loop --//
+    let rx = spawn_reader_thread(master_fd);
+
+    let window = ApplicationWindow::builder()
+        .application(app)
+        .title(config::WINDOW_TITLE)
+        .default_width(config::WINDOW_WIDTH)
+        .default_height(config::WINDOW_HEIGHT)
+        .build();
+
+    let drawing_area = DrawingArea::new();
+    drawing_area.set_focusable(true);
+
+    setup_draw_func(&drawing_area, &text_buffer, &cursor_visible);
+    setup_poll_timer(rx, &drawing_area, &text_buffer, &cursor_visible, &window);
+    setup_blink_timer(&drawing_area, &cursor_visible);
+    setup_keyboard(&drawing_area, master_fd);
+
+    window.set_child(Some(&drawing_area));
+    window.present();
+}
+
+///
+/// #### **<ins>Function</ins>**
+/// ```Rust
+///     spawn_reader_thread(master_fd: RawFd) -> std::sync::mpsc::Receiver<Vec<u8>>
+/// ```
+/// Spawns a background thread that reads raw bytes from the PTY master fd
+/// and sends them to the GTK main thread via an mpsc channel.
+///
+/// ### Arguments
+/// - `master_fd`: PTY master "RAW" file descriptor to read from
+///
+/// ### Returns
+/// The receiving end of the channel. Each message is a `Vec<u8>` chunk
+/// of raw PTY output (up to `config::PTY_READ_BUF_SIZE` bytes).
+///
+/// ### Thread Lifecycle
+/// The thread terminates when:
+/// - `read()` returns 0 (EOF, shell closed its stdout)
+/// - `read()` returns `Errno::EIO` (slave side of PTY closed)
+/// - The channel receiver is dropped (GTK side shut down)
+///
+fn spawn_reader_thread(master_fd: RawFd) -> std::sync::mpsc::Receiver<Vec<u8>> {
     let (tx, rx) = std::sync::mpsc::channel::<Vec<u8>>();
 
-    let reader_fd = master_fd;
+    let reader_fd: RawFd = master_fd;
     std::thread::spawn(move || {
-        let mut buf = [0u8; config::PTY_READ_BUF_SIZE];
+        let mut buf: [u8; config::PTY_READ_BUF_SIZE] = [0u8; config::PTY_READ_BUF_SIZE];
         loop {
             match unistd::read(reader_fd, &mut buf) {
                 //-- EOF: shell closed --//
@@ -115,18 +157,38 @@ fn build_ui(app: &Application, master_fd: RawFd) -> () {
         }
     });
 
-    let window = ApplicationWindow::builder()
-        .application(app)
-        .title(config::WINDOW_TITLE)
-        .default_width(config::WINDOW_WIDTH)
-        .default_height(config::WINDOW_HEIGHT)
-        .build();
+    return rx;
+}
 
-    let drawing_area = DrawingArea::new();
-    drawing_area.set_focusable(true);
-
+///
+/// #### **<ins>Function</ins>**
+/// ```Rust
+///     setup_draw_func(
+///         drawing_area: &DrawingArea,
+///         text_buffer: &Rc<RefCell<String>>,
+///         cursor_visible: &Rc<RefCell<bool>>,
+///     ) -> ()
+/// ```
+/// Installs the Cairo draw callback on the `DrawingArea`.
+///
+/// ### Arguments
+/// - `drawing_area`: GTK drawing surface to attach the callback to
+/// - `text_buffer`: Shared terminal text (read during each frame)
+/// - `cursor_visible`: Shared blink state (read during each frame)
+///
+/// ### Rendering
+/// - Fills the background with `config::BG_COLOR`
+/// - Renders the last N lines (that fit the window height) in monospace
+/// - Draws a block cursor at the end of the last visible line when `cursor_visible` is true
+///
+fn setup_draw_func(
+    drawing_area: &DrawingArea,
+    text_buffer: &Rc<RefCell<String>>,
+    cursor_visible: &Rc<RefCell<bool>>,
+) -> () {
     let buf_for_draw = text_buffer.clone();
     let cv_for_draw = cursor_visible.clone();
+
     drawing_area.set_draw_func(move |_widget, ctx, width, height| {
         //-- Background fill --//
         ctx.set_source_rgb(config::BG_COLOR.0, config::BG_COLOR.1, config::BG_COLOR.2);
@@ -183,17 +245,62 @@ fn build_ui(app: &Application, master_fd: RawFd) -> () {
             let _ = ctx.fill();
         }
     });
+}
 
+///
+/// #### **<ins>Function</ins>**
+/// ```Rust
+///     setup_poll_timer(
+///         rx: std::sync::mpsc::Receiver<Vec<u8>>,
+///         drawing_area: &DrawingArea,
+///         text_buffer: &Rc<RefCell<String>>,
+///         cursor_visible: &Rc<RefCell<bool>>,
+///     ) -> ()
+/// ```
+/// Starts a 16ms (~60 fps) timer on the GTK main loop that drains the
+/// reader thread's channel and updates the terminal display.
+///
+/// ### Arguments
+/// - `rx`: Receiving end of the PTY reader channel (consumed, moved into closure)
+/// - `drawing_area`: Widget to `queue_draw()` when new output arrives
+/// - `text_buffer`: Shared buffer to append processed output into
+/// - `cursor_visible`: Reset to `true` on new output (interrupts blink)
+/// - `window`: Application window — closed when the shell exits (triggers app quit)
+///
+/// ### Behavior
+/// Each tick drains all pending messages from `rx`, feeds each chunk
+/// through `process_pty_output()`, and triggers a redraw if anything changed.
+/// When the channel disconnects (shell exited, reader thread ended),
+/// closes the window which causes the GTK application to quit.
+///
+fn setup_poll_timer(
+    rx: std::sync::mpsc::Receiver<Vec<u8>>,
+    drawing_area: &DrawingArea,
+    text_buffer: &Rc<RefCell<String>>,
+    cursor_visible: &Rc<RefCell<bool>>,
+    window: &ApplicationWindow,
+) -> () {
     let buf_for_rx = text_buffer.clone();
     let cv_for_rx = cursor_visible.clone();
     let da_for_rx = drawing_area.clone();
+    let win_for_rx = window.clone();
 
     glib::timeout_add_local(std::time::Duration::from_millis(16), move || {
         let mut needs_redraw = false;
 
-        while let Ok(data) = rx.try_recv() {
-            process_pty_output(&mut buf_for_rx.borrow_mut(), &data);
-            needs_redraw = true;
+        loop {
+            match rx.try_recv() {
+                Ok(data) => {
+                    process_pty_output(&mut buf_for_rx.borrow_mut(), &data);
+                    needs_redraw = true;
+                }
+                Err(std::sync::mpsc::TryRecvError::Empty) => break,
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                    //-- Shell exited: close window → quit app --//
+                    win_for_rx.close();
+                    return glib::ControlFlow::Break;
+                }
+            }
         }
 
         if needs_redraw {
@@ -204,18 +311,60 @@ fn build_ui(app: &Application, master_fd: RawFd) -> () {
 
         glib::ControlFlow::Continue
     });
+}
 
-    //-- Cursor blink timer (~500 ms) --//
+///
+/// #### **<ins>Function</ins>**
+/// ```Rust
+///     setup_blink_timer(
+///         drawing_area: &DrawingArea,
+///         cursor_visible: &Rc<RefCell<bool>>,
+///     ) -> ()
+/// ```
+/// Starts a 500ms timer that toggles cursor visibility and redraws.
+///
+/// ### Arguments
+/// - `drawing_area`: Widget to `queue_draw()` on each blink toggle
+/// - `cursor_visible`: Shared flag toggled every 500ms
+///
+fn setup_blink_timer(drawing_area: &DrawingArea, cursor_visible: &Rc<RefCell<bool>>) -> () {
     let cv_for_blink = cursor_visible.clone();
     let da_for_blink = drawing_area.clone();
+
     glib::timeout_add_local(std::time::Duration::from_millis(500), move || {
         let mut vis = cv_for_blink.borrow_mut();
         *vis = !*vis;
         da_for_blink.queue_draw();
         glib::ControlFlow::Continue
     });
+}
 
-    //-- Keyboard input → PTY master fd --//
+///
+/// #### **<ins>Function</ins>**
+/// ```Rust
+///     setup_keyboard(drawing_area: &DrawingArea, master_fd: RawFd) -> ()
+/// ```
+/// Installs a keyboard event controller on the `DrawingArea` that translates
+/// GTK key events into byte sequences and writes them to the PTY master fd.
+///
+/// ### Arguments
+/// - `drawing_area`: Widget to attach the `EventControllerKey` to
+/// - `master_fd`: PTY master fd to write translated key bytes into
+///
+/// ### Key Mapping
+/// | Input              | Bytes written to PTY        |
+/// |--------------------|-----------------------------|
+/// | Ctrl+\<letter\>    | Control character 0x01-0x1A |
+/// | Enter              | `\r`                        |
+/// | Backspace          | `\x7f` (DEL)               |
+/// | Tab                | `\t`                        |
+/// | Escape             | `\x1b`                      |
+/// | Arrow keys         | `\x1b[A`-`\x1b[D`          |
+/// | Delete             | `\x1b[3~`                   |
+/// | Home / End         | `\x1b[H` / `\x1b[F`        |
+/// | Printable chars    | UTF-8 encoded bytes         |
+///
+fn setup_keyboard(drawing_area: &DrawingArea, master_fd: RawFd) -> () {
     let key_controller = EventControllerKey::new();
     let writer_fd = master_fd;
 
@@ -280,10 +429,7 @@ fn build_ui(app: &Application, master_fd: RawFd) -> () {
         glib::Propagation::Stop
     });
 
-    //-- Assemble and present --//
-    window.add_controller(key_controller);
-    window.set_child(Some(&drawing_area));
-    window.present();
+    drawing_area.add_controller(key_controller);
 }
 
 ///
@@ -337,15 +483,32 @@ fn process_pty_output(buffer: &mut String, data: &[u8]) {
             //-- ANSI escape sequences --//
             '\x1b' => {
                 match chars.peek() {
-                    //-- CSI sequence: \x1b[ … <final byte> --//
+                    //-- CSI sequence: \x1b[ <params> <final byte> --//
                     Some(&'[') => {
                         chars.next();
+                        let mut params = String::new();
+                        let final_byte;
                         loop {
                             match chars.next() {
-                                Some(c) if ('@'..='~').contains(&c) => break,
-                                Some(_) => continue,
-                                None => break,
+                                Some(c) if ('@'..='~').contains(&c) => {
+                                    final_byte = Some(c);
+                                    break;
+                                }
+                                Some(c) => params.push(c),
+                                None => {
+                                    final_byte = None;
+                                    break;
+                                }
                             }
+                        }
+                        //-- Act on recognized CSI sequences --//
+                        match final_byte {
+                            //-- ED (Erase in Display) --//
+                            //-- \x1b[2J = clear screen, \x1b[3J = clear scrollback --//
+                            Some('J') if params == "2" || params == "3" => {
+                                buffer.clear();
+                            }
+                            _ => {}
                         }
                     }
                     //-- OSC sequence: \x1b] … (BEL | ST) --//


### PR DESCRIPTION
This PR delivers 3 changes to [src/rushx_term/mod.rs](https://github.com/The-HaiKaw-Pr0tocol/RushX/blob/main/src/rushx_term/mod.rs):

1. **`clear` command support** : The terminal now interprets CSI `2J` and `3J` escape sequences (Erase in Display) by clearing the text buffer, so `clear` works as expected.
2. **`exit` kills the entire application** when the shell exits, the reader thread drops its channel sender; the poll timer detects the disconnect and closes the window, which quits the GTK application cleanly.
3. **`build_ui()` decomposition** : The monolithic ~170-line `build_ui()` function has been broken into 5 focused helper functions, each with full doc comments.