### PR TITLE
feat(parser): add POSIX-compliant argument parser with quote handling

### DIFF
--- a/src/rushx_shell/mod.rs
+++ b/src/rushx_shell/mod.rs
@@ -50,13 +50,13 @@ pub fn run_rushx_shell() -> () {
             break;
         }
 
-        let args: Vec<&str> = input_buffer.split_whitespace().collect();
+        let args = parser::parse_args(input_buffer.trim());
 
         if args.is_empty() {
             continue;
         }
 
-        match args[0] {
+        match args[0].as_str() {
             "exit" => break,
             "echo" => {
                 if args.len() > 1 {
@@ -69,7 +69,7 @@ pub fn run_rushx_shell() -> () {
                 if args.len() < 2 {
                     println!("type: missing operand");
                 } else {
-                    exec::type_command(args[1]);
+                    exec::type_command(&args[1]);
                 }
             }
             "pwd" => {
@@ -112,7 +112,10 @@ pub fn run_rushx_shell() -> () {
                     eprintln!("cd: {}: No such file or directory", resolved);
                 }
             }
-            _ => exec::run_external(args[0], &args),
+            _ => {
+                let str_args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+                exec::run_external(&args[0], &str_args);
+            }
         }
     }
 }

--- a/src/rushx_shell/parser/mod.rs
+++ b/src/rushx_shell/parser/mod.rs
@@ -19,3 +19,5 @@
 
 pub mod lexer;
 pub mod parse;
+
+pub use parse::parse_args;

--- a/src/rushx_shell/parser/parse.rs
+++ b/src/rushx_shell/parser/parse.rs
@@ -16,3 +16,99 @@
 //
 
 /*=============================================================================*/
+
+///
+/// #### **<ins>Function</ins>**
+/// ```Rust
+///     parse_args(input: &str) -> Vec<String>
+/// ```
+/// Splits a raw input line into arguments with POSIX-style quote handling.
+///
+/// ### Arguments
+/// - `input`: Raw input string from the user
+///
+/// ### Returns
+/// A vector of parsed argument strings, respecting single quotes,
+/// double quotes, and backslash escapes.
+///
+/// ### Quote Rules
+/// - **Single quotes**: preserve literal content, no escape processing
+/// - **Double quotes**: allow `\\`, `\"`, `\$`, `` \` ``, `\newline` escapes
+/// - **Unquoted backslash**: escapes the next character
+///
+pub fn parse_args(input: &str) -> Vec<String> {
+    let mut args = Vec::new();
+    let mut current = String::new();
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut has_content = false;
+
+    let chars: Vec<char> = input.chars().collect();
+    let mut i = 0;
+
+    while i < chars.len() {
+        let c = chars[i];
+        if in_single_quote {
+            if c == '\'' {
+                in_single_quote = false;
+            } else {
+                current.push(c);
+            }
+        } else if in_double_quote {
+            if c == '"' {
+                in_double_quote = false;
+            } else if c == '\\' {
+                if i + 1 < chars.len() {
+                    let next = chars[i + 1];
+                    if next == '\\' || next == '"' || next == '$' || next == '`' || next == '\n' {
+                        current.push(next);
+                        i += 1;
+                    } else {
+                        current.push(c);
+                    }
+                } else {
+                    current.push(c);
+                }
+            } else {
+                current.push(c);
+            }
+        } else {
+            match c {
+                '\\' => {
+                    // Backslash outside quotes: escape next character
+                    i += 1;
+                    if i < chars.len() {
+                        current.push(chars[i]);
+                        has_content = true;
+                    }
+                }
+                '\'' => {
+                    in_single_quote = true;
+                    has_content = true;
+                }
+                '"' => {
+                    in_double_quote = true;
+                    has_content = true;
+                }
+                ' ' | '\t' => {
+                    if has_content || !current.is_empty() {
+                        args.push(current.clone());
+                        current.clear();
+                        has_content = false;
+                    }
+                }
+                _ => {
+                    current.push(c);
+                    has_content = true;
+                }
+            }
+        }
+        i += 1;
+    }
+
+    if has_content || !current.is_empty() {
+        args.push(current);
+    }
+
+    args
+}


### PR DESCRIPTION
### PR TYPE 
feat(parser)

### Summary
Replace `split_whitespace()` argument splitting in the shell REPL with a proper POSIX-style `parse_args()` function to correctly handle quotes and escape sequences.

### Changes
- Add `parse_args()` to the parser : this function splits raw input into args respecting single quotes, double quotes, and backslash escapes
- Update `run_rushx_shell()` to use `parse_args()` instead of `split_whitespace()`

### Behavior
| Feature | Before | After |
|---|---|---|
| `echo "hello world"` | `hello` `"hello` `world"` | `hello world` |
| `echo 'no\escape'` | `no\escape` | `no\escape` |
| `echo hello\ world` | `hello\` `world` | `hello world` |
| `echo "back\\slash"` | `"back\\slash"` | `back\slash` |
| Adjacent quotes (`"a"'b'`) | Split incorrectly | Merged into `ab` |

