### PR TITLE
- fix(release/debian): Corrected Desktop Icon Installation + Added .deb file renaming step with version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,12 @@ jobs:
                   mkdir -p dist
                   mv ../*.deb dist/
 
+            - name: Rename .deb with tag
+              run: |
+                  tag="${GITHUB_REF_NAME:-${GITHUB_REF##*/}}"
+                  debfile=$(ls dist/*.deb) 
+                  mv "$debfile" "dist/rushx-${tag}.deb"
+
             - name: Import APT signing key
               env:
                   APT_GPG_PRIVATE_KEY: ${{ secrets.APT_GPG_PRIVATE_KEY }}

--- a/debian/rules
+++ b/debian/rules
@@ -11,3 +11,4 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	install -Dm755 target/release/rushx $(CURDIR)/debian/rushx/usr/bin/rushx
+	dh_install --sourcedir=$(CURDIR)


### PR DESCRIPTION
This PR mainly: 

- Ensures RushX desktop icon and `.desktop` entry are installed by updating rules to call `dh_install`.
- Adds a step in the GitHub Actions [release workflow](https://github.com/The-HaiKaw-Pr0tocol/RushX/blob/main/.github/workflows/release.yml) to rename the `.deb` file with the tag number, ensuring versioned `.deb` files for each release.

---

- **debian/rules**  
  - Calls `dh_install` after binary install, so desktop icon and entry are placed in system directories as specified in install.
- **release.yml**  
  - Adds a step to rename the `.deb` file in `dist/` to include the tag (e.g., `rushx-v1.2.3.deb`).

---

RushX now installs with a desktop icon, and each release `.deb` is uniquely versioned by tag.